### PR TITLE
major update to schema, with seed and types

### DIFF
--- a/src/model/schema.sql
+++ b/src/model/schema.sql
@@ -1,43 +1,66 @@
-CREATE TABLE users(
-    id serial PRIMARY KEY,
+DROP TABLE IF EXISTS webdictionary_preferences;
+DROP TABLE IF EXISTS users_words;
+DROP TABLE IF EXISTS users_translations;
+DROP TABLE IF EXISTS users_know_languages;
+DROP TABLE IF EXISTS users_study_languages;
+DROP TABLE IF EXISTS webdictionaries;
+DROP TABLE IF EXISTS languagepairs;
+DROP TABLE IF EXISTS contexts;
+DROP TABLE IF EXISTS translations;
+DROP TABLE IF EXISTS texts;
+DROP TABLE IF EXISTS words;
+DROP TABLE IF EXISTS languages;
+DROP TABLE IF EXISTS admins;
+DROP TABLE IF EXISTS users;
+
+
+CREATE TABLE users (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     username text UNIQUE NOT NULL,
     password_hash text NOT NULL,
     email text UNIQUE NOT NULL
 );
 
 
-CREATE TABLE admins(
+CREATE TABLE admins (
     user_id int PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE
 );
 
 
-CREATE TABLE languages(
-    id serial PRIMARY KEY,
-    "name" text UNIQUE NOT NULL,
-    abbreviation varchar(8) UNIQUE NOT NULL,
+/* language name must same as associated postgres dictionary name*/
+CREATE TABLE languages (
+    id varchar(4) PRIMARY KEY,
+    "name" varchar(32) UNIQUE NOT NULL,
     google_translate_url text,
     each_char_is_word boolean DEFAULT false,
     is_right_to_left boolean DEFAULT false
 );
 
 
-CREATE TABLE words(
-    id serial PRIMARY KEY,
-    language_id int REFERENCES languages (id) ON DELETE CASCADE,
+CREATE TABLE words (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
+    language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE,
     word text NOT NULL,
-    ts_parsed_word tsquery NOT NULL,
-    is_compound boolean NOT NULL
+    ts_config regconfig NOT NULL,
+    tsquery_simple tsquery
+        GENERATED ALWAYS AS (phraseto_tsquery('simple', word)) STORED,
+    tsquery_language tsquery
+        GENERATED ALWAYS AS (phraseto_tsquery(ts_config, word)) STORED
 );
 
 
-CREATE TABLE texts(
-    id serial PRIMARY KEY,
+CREATE TABLE texts (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id),
-    language_id int REFERENCES languages (id),
+    language_id varchar(4) REFERENCES languages (id),
     title text NOT NULL,
     author text,
-    "text" text NOT NULL,
-    ts_parsed_text tsvector NOT NULL,
+    body text NOT NULL,
+    ts_config regconfig NOT NULL,
+    tsvector_simple tsvector 
+        GENERATED ALWAYS AS (to_tsvector('simple', body)) STORED,
+    tsvector_language tsvector
+        GENERATED ALWAYS AS (to_tsvector(ts_config, body)) STORED,
     source_url text,
     source_type text,
     upload_time timestamptz DEFAULT now(),
@@ -45,16 +68,20 @@ CREATE TABLE texts(
 );
 
 
-CREATE TABLE translations(
-    id serial PRIMARY KEY,
+CREATE INDEX ts_simple_idx ON texts USING GIN (tsvector_simple);
+CREATE INDEX ts_language_idx ON texts USING GIN (tsvector_language);
+
+
+CREATE TABLE translations (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     word_id int REFERENCES words (id) ON DELETE CASCADE,
-    translation text NOT NULL,
-    target_language_id int REFERENCES languages (id) ON DELETE CASCADE
+    target_language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE,
+    translation text NOT NULL
 );
 
 
-CREATE TABLE contexts(
-    id serial PRIMARY KEY,
+CREATE TABLE contexts (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     text_id int REFERENCES texts (id) ON DELETE CASCADE,
     translation_id int REFERENCES translations (id) ON DELETE CASCADE,
     snippet text NOT NULL
@@ -62,53 +89,52 @@ CREATE TABLE contexts(
 
 
 CREATE TABLE languagepairs (
-    id serial PRIMARY KEY,
-    source_language_id int REFERENCES languages (id) ON DELETE CASCADE,
-    target_language_id int REFERENCES languages (id) ON DELETE CASCADE
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
+    source_language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE,
+    target_language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE
 );
 
 
 CREATE TABLE webdictionaries (
-    id serial PRIMARY KEY,
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     language_pair_id int REFERENCES languagepairs (id) ON DELETE CASCADE,
     "name" int NOT NULL,
     "url" int NOT NULL
 );
 
 
-CREATE TABLE users_study_languages(
-    id serial PRIMARY KEY,
+CREATE TABLE users_study_languages (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id) ON DELETE CASCADE,
-    study_language_id int REFERENCES languages (id) ON DELETE CASCADE
+    study_language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE
 );
 
 
-CREATE TABLE users_know_languages(
-    id serial PRIMARY KEY,
+CREATE TABLE users_know_languages (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id) ON DELETE CASCADE,
-    known_language_id int REFERENCES languages (id) ON DELETE CASCADE,
+    known_language_id varchar(4) REFERENCES languages (id) ON DELETE CASCADE,
     is_native boolean NOT NULL
 );
 
 
-CREATE TABLE users_translations(
-    id serial PRIMARY KEY,
+CREATE TABLE users_translations (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id) ON DELETE CASCADE,
     translation_id int REFERENCES translations (id) ON DELETE CASCADE
 );
 
 
-CREATE TABLE users_words(
-    id serial PRIMARY KEY,
+CREATE TABLE users_words (
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id) ON DELETE CASCADE,
     word_id int REFERENCES words (id) ON DELETE CASCADE,
-    word_status varchar(64) NOT NULL
+    word_status varchar(32) NOT NULL
 );
 
 
 CREATE TABLE webdictionary_preferences (
-    id serial PRIMARY KEY,
+    id integer PRIMARY KEY GENERATED ALWAYS AS identity,
     user_id int REFERENCES users (id) ON DELETE CASCADE,
     webdictionary_id int REFERENCES webdictionaries (id) ON DELETE CASCADE
 );
-

--- a/src/model/seed.sql
+++ b/src/model/seed.sql
@@ -8,42 +8,115 @@ DELETE FROM contexts;
 DELETE FROM languagepairs;
 DELETE FROM webdictionaries;
 
+
 INSERT INTO users (username, password_hash, email)
 VALUES
-('test', 'pwhash', 'test@example.com');
+('eamon', 'eamonpwhash', 'eamon@example.com'),
+('dana', 'danapwhash', 'dana@example.com'),
+('marc', 'marcpwhash', 'marc@example.com');
 
-INSERT INTO languages ("name", abbreviation)
+
+INSERT INTO languages (id, "name") 
 VALUES
-('English', 'en'),
-('German', 'de'),
-('French', 'fr');
+('en', 'english'),
+('de', 'german'),
+('fr', 'french');
 
-INSERT INTO texts (user_id, language_id, title, "text", ts_parsed_text)
+
+INSERT INTO texts (user_id, language_id, title, body, ts_config) 
 VALUES
 (
-1, 1, 'The Little Match Girl',
+1, 'en', 'The Little Match Girl', 
 'It was so terribly cold. Snow was falling, and it was almost dark. Evening came on, the last evening of the year. In the cold and gloom a poor little girl, bareheaded and barefoot, was walking through the streets. Of course when she had left her house she''d had slippers on, but what good had they been? They were very big slippers, way too big for her, for they belonged to her mother. The little girl had lost them running across the road, where two carriages had rattled by terribly fast. One slipper she''d not been able to find again, and a boy had run off with the other, saying he could use it very well as a cradle some day when he had children of his own. And so the little girl walked on her naked feet, which were quite red and blue with the cold. In an old apron she carried several packages of matches, and she held a box of them in her hand. No one had bought any from her all day long, and no one had given her a cent.',
-to_tsvector('It was so terribly cold. Snow was falling, and it was almost dark. Evening came on, the last evening of the year. In the cold and gloom a poor little girl, bareheaded and barefoot, was walking through the streets. Of course when she had left her house she''d had slippers on, but what good had they been? They were very big slippers, way too big for her, for they belonged to her mother. The little girl had lost them running across the road, where two carriages had rattled by terribly fast. One slipper she''d not been able to find again, and a boy had run off with the other, saying he could use it very well as a cradle some day when he had children of his own. And so the little girl walked on her naked feet, which were quite red and blue with the cold. In an old apron she carried several packages of matches, and she held a box of them in her hand. No one had bought any from her all day long, and no one had given her a cent.')
+'english'
+),
+(
+1, 'en', 'The Little Match Girl', 
+'It was so terribly cold. Snow was falling, and it was almost dark. Evening came on, the last evening of the year. In the cold and gloom a poor little girl, bareheaded and barefoot, was walking through the streets. Of course when she had left her house she''d had slippers on, but what good had they been? They were very big slippers, way too big for her, for they belonged to her mother. The little girl had lost them running across the road, where two carriages had rattled by terribly fast. One slipper she''d not been able to find again, and a boy had run off with the other, saying he could use it very well as a cradle some day when he had children of his own. And so the little girl walked on her naked feet, which were quite red and blue with the cold. In an old apron she carried several packages of matches, and she held a box of them in her hand. No one had bought any from her all day long, and no one had given her a cent.',
+'english'
+),
+(
+1, 'en', 'The Little Match Girl', 
+'It was so terribly cold. Snow was falling, and it was almost dark. Evening came on, the last evening of the year. In the cold and gloom a poor little girl, bareheaded and barefoot, was walking through the streets. Of course when she had left her house she''d had slippers on, but what good had they been? They were very big slippers, way too big for her, for they belonged to her mother. The little girl had lost them running across the road, where two carriages had rattled by terribly fast. One slipper she''d not been able to find again, and a boy had run off with the other, saying he could use it very well as a cradle some day when he had children of his own. And so the little girl walked on her naked feet, which were quite red and blue with the cold. In an old apron she carried several packages of matches, and she held a box of them in her hand. No one had bought any from her all day long, and no one had given her a cent.',
+'english'
 );
 
-INSERT INTO words (language_id, word, ts_parsed_word, is_compound)
-VALUES
-(1, 'of course', phraseto_tsquery('of course'), true),
-(1, 'hunger', phraseto_tsquery('hunger'), false),
-(1, 'across the road', phraseto_tsquery('across the road'),true),
-(1, 'hunger', phraseto_tsquery('hunger'), false),
-(1, 'all day long', phraseto_tsquery('all day long'), true),
-(1, 'snowflakes', phraseto_tsquery('snowflakes'), false),
-(1, 'roast goose', phraseto_tsquery('roast goose'), true),
-(1, 'bareheaded', phraseto_tsquery('bareheaded'),false),
-(1, 'rattled by', phraseto_tsquery('rattled by'), true),
-(1, 'carriages', phraseto_tsquery('carriages'), false),
-(1, 'New Year''s eve', phraseto_tsquery('New Year''s eve'), true);
 
-INSERT INTO users_words(user_id, word_id, word_status)
+
+INSERT INTO words (language_id, word, ts_config)
+VALUES
+('en', 'of course', 'english'),
+('en', 'hunger', 'english'),
+('en', 'across the road', 'english'),
+('en', 'all day long', 'english'),
+('en', 'snowflakes', 'english'),
+('en', 'roast goose', 'english'),
+('en', 'bareheaded', 'english'),
+('en', 'rattled by', 'english'),
+('en', 'carriages', 'english'),
+('en', 'New Year''s eve', 'english');
+
+
+INSERT INTO translations (word_id, target_language_id, translation)
+VALUES
+(1, 'de', 'natürlich'),
+(1, 'de', 'klar doch'),
+(2, 'de', 'Hunger'),
+(3, 'de', 'gegenüber'),
+(3, 'de', 'über die Straße'),
+(4, 'de', 'den ganzen Tag'),
+(5, 'de', 'Schneeflocken'),
+(6, 'de', 'Gänsebraten'),
+(7, 'de', 'barhäuptig'),
+(8, 'de', 'vorbeigeklappert'),
+(9, 'de', 'Wagen'),
+(10, 'de', 'Silvester'),
+(1, 'fr', 'bien sûr'),
+(2, 'fr', 'faim'),
+(3, 'fr', 'à travers la route'),
+(4, 'fr', 'toute la journée'),
+(5, 'fr', 'flocons de neige'),
+(6, 'fr', 'oie rôtie'),
+(7, 'fr', 'tête nue'),
+(8, 'fr', 'ébranlé par'),
+(9, 'fr', 'chariots'),
+(10, 'fr', 'Réveillon de Nouvel an');
+
+
+INSERT INTO contexts (text_id, translation_id, snippet) 
+VALUES
+(1, 9, 'poor little girl, bareheaded and barefoot, was'),
+(1, 21, 'road, where two carriages had rattled by');
+
+
+INSERT INTO users_words (user_id, word_id, word_status)
 VALUES
 (1, 1, 'learning'),
 (1, 3, 'known'),
 (1, 5, 'learning'),
 (1, 7, 'known'),
-(1, 9, 'learning');
+(1, 9, 'learning'),
+(2, 2, 'learning'),
+(2, 4, 'known'),
+(2, 6, 'learning'),
+(2, 8, 'known'),
+(2, 10, 'learning'),
+(3, 1, 'learning'),
+(3, 2, 'known'),
+(3, 5, 'learning'),
+(3, 6, 'known'),
+(3, 7, 'learning');
+
+
+INSERT INTO users_translations (user_id, translation_id)
+VALUES
+(1, 1),
+(1, 5),
+(1, 16),
+(2, 5),
+(2, 18),
+(2, 10),
+(3, 8),
+(3, 9),
+(3, 10);
+

--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -1,0 +1,60 @@
+import dbQuery from '../model/db-query';
+import { Language, LanguageDB, convertLanguageTypes } from '../types';
+
+const getAll = async function(): Promise<Array<Language> | null> {
+  const ALL_LANGUAGES: string = `
+    SELECT * FROM languages`;
+
+  const result = await dbQuery(ALL_LANGUAGES);
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return result.rows.map((dbItem: LanguageDB) => convertLanguageTypes(dbItem));
+};
+
+
+const getOne = async function(languageId: string): Promise<Language | null> {
+  const LANGUAGE_BY_ID: string = `
+    SELECT * FROM languages WHERE id = %L`;
+
+  const result = await dbQuery(LANGUAGE_BY_ID, languageId);
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return result.rows[0];
+};
+
+
+const addNew = async function(languageData: Language) {
+  const {
+    id,
+    name,
+    googleTranslateURL,
+    eachCharIsWord,
+    isRightToLeft,
+  } = languageData;
+
+  const ADD_LANGUAGE: string = `
+    INSERT INTO languages 
+    (id, name, google_translate_url, each_word_is_char, is_right_to_left)
+    VALUES 
+    (%L, %L, %L, %L, %L)`;
+
+  await dbQuery(
+    ADD_LANGUAGE,
+    id,
+    name,
+    googleTranslateURL || null,
+    eachCharIsWord,
+    isRightToLeft,
+  );
+};
+
+
+export default {
+  getAll,
+  getOne,
+  addNew,
+};

--- a/src/services/texts.ts
+++ b/src/services/texts.ts
@@ -34,16 +34,18 @@ const addNew = async function(textData: Text) {
     languageId,
     title,
     author,
-    text,
+    body,
     sourceURL,
     sourceType,
   } = textData;
 
   const ADD_TEXT: string = `
     INSERT INTO texts 
-    (user_id, language_id, title, author, text, ts_parsed_text, source_url, source_type)
+    (user_id, language_id, title, author, body, ts_config, source_url, source_type)
     VALUES 
-    (%s, %s, %L, %L, %L, to_tsvector(%L), %L, %L)`;
+    (%s, %L, %L, %L, %L, %L, %L, %L)`;
+
+  const tsConfig = 'english';
 
   await dbQuery(
     ADD_TEXT,
@@ -51,8 +53,8 @@ const addNew = async function(textData: Text) {
     languageId,
     title,
     author || null,
-    text,
-    text,
+    body,
+    tsConfig,
     sourceURL || null,
     sourceType || null,
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,3 +77,30 @@ export const convertWordTypes = function(dbItem: WordDB): Word {
     word: dbItem.word,
   };
 };
+
+
+export type Language = {
+  id: string,
+  name: string,
+  googleTranslateURL?: string | null,
+  eachCharIsWord: boolean,
+  isRightToLeft: boolean
+};
+
+export type LanguageDB = {
+  id: string,
+  name: string,
+  google_translate_url: string | null,
+  each_char_is_word: boolean,
+  is_right_to_left: boolean
+};
+
+export const convertLanguageTypes = function(dbItem: LanguageDB): Language {
+  return {
+    id: dbItem.id,
+    name: dbItem.name,
+    googleTranslateURL: dbItem.google_translate_url,
+    eachCharIsWord: dbItem.each_char_is_word,
+    isRightToLeft: dbItem.is_right_to_left,
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,36 +6,37 @@ export type ConnectionOptions = {
 export interface User {
   username: string,
   passwordHash: string,
-  email: string
+  email: string,
 }
 
 
 export type Text = {
   id?: number,
   userId: number,
-  languageId: number,
+  languageId: string,
   title: string,
   author?: string | null,
-  text: string,
-  tsParsedText?: string,
+  body: string,
   sourceURL?: string | null,
   sourceType?: string | null,
   uploadTime: Date,
-  isPublic?: boolean
+  isPublic?: boolean,
 };
 
 export type TextDB = {
   id: number,
   user_id: number,
-  language_id: number,
+  language_id: string,
   title: string,
   author: string | null,
-  text: string,
-  ts_parsed_text: string,
+  body: string,
+  ts_config: string,
+  tsvector_simple: string,
+  tsvector_language: string,
   source_url: string | null,
   source_type: string | null,
   upload_time: string,
-  is_public: boolean
+  is_public: boolean,
 };
 
 export const convertTextTypes = function(dbItem: TextDB): Text {
@@ -45,8 +46,7 @@ export const convertTextTypes = function(dbItem: TextDB): Text {
     languageId: dbItem.language_id,
     title: dbItem.title,
     author: dbItem.author,
-    text: dbItem.text,
-    tsParsedText: dbItem.ts_parsed_text,
+    body: dbItem.body,
     sourceURL: dbItem.source_url,
     sourceType: dbItem.source_type,
     uploadTime: new Date(dbItem.upload_time),
@@ -59,16 +59,15 @@ export type Word = {
   id: number,
   languageId: number,
   word: string,
-  tsParsedWord: string,
-  isCompound: boolean
 };
 
 export type WordDB = {
   id: number,
   language_id: number,
   word: string,
-  ts_parsed_word: string,
-  is_compound: boolean
+  ts_config: string,
+  tsquery_simple: string,
+  tsquery_language: string,
 };
 
 export const convertWordTypes = function(dbItem: WordDB): Word {
@@ -76,7 +75,5 @@ export const convertWordTypes = function(dbItem: WordDB): Word {
     id: dbItem.id,
     languageId: dbItem.language_id,
     word: dbItem.word,
-    tsParsedWord: dbItem.ts_parsed_word,
-    isCompound: dbItem.is_compound,
   };
 };


### PR DESCRIPTION
- There are a couple of big changes to the DB schema. Next I will update the database design document accordingly. 
  - The `id` of a language is now an abbreviation of max. 4 letters. I suggest 2 letters. 
  - `serial` for the other `id`s has been replaced by generated column. 
  - Each text and word is parsed with two different dictionaries, a simple generic one and a language specific one. This leaves more options for the search.
  - The `is_compound` column of the `words` table is gone. 

- The seed file should contain enough data for a fresh start with the new DB schema. 

- The `types.ts` has been adjusted according to the new schema. 