### PR TITLE
Split app into app and server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "scripts": {
     "tsc": "tsc",
-    "dev": "cross-env NODE_ENV=development ts-node-dev src/app.ts",
-    "staging": "cross-env NODE_ENV=staging ts-node-dev src/app.ts",
+    "dev": "cross-env NODE_ENV=development ts-node-dev src/server.ts",
+    "staging": "cross-env NODE_ENV=staging ts-node-dev src/server.ts",
     "lint": "eslint --ext .ts .",
-    "start": "node build/app.js",
+    "start": "node build/server.js",
     "test": "NODE_ENV=test jest --verbose --runInBand"
   },
   "repository": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,18 +1,14 @@
 import express from 'express';
 import cors from 'cors';
-import config from './lib/config';
 
 import textsRouter from './routes/texts';
 import translationsRouter from './routes/translations';
 import usersRouter from './routes/users';
 import wordsRouter from './routes/words';
-// import { unknownEndpoint } from './utils/middleware';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
-
-const { PORT, HOST } = config;
 
 app.get('/ping', (_req, res) => {
   console.log('someone pinged here');
@@ -23,10 +19,5 @@ app.use('/api/texts', textsRouter);
 app.use('/api/translations', translationsRouter);
 app.use('/api/users', usersRouter);
 app.use('/api/words', wordsRouter);
-// app.use(unknownEndpoint);
-
-app.listen(Number(PORT), String(HOST), () => {
-  console.log(`That word-learn app is listening on port ${PORT} of ${HOST}.`);
-});
 
 export default app;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,11 @@
+import http from 'http';
+import app from './app';
+import config from './lib/config';
+
+const server = http.createServer(app);
+
+const { PORT, HOST } = config;
+
+server.listen(Number(PORT), String(HOST), () => {
+  console.log(`That word-learn app is listening on port ${PORT} of ${HOST}.`);
+});


### PR DESCRIPTION
I split the `app` module into two parts, moving the actual starting of the server to its own module, `server.ts`. This is necessary for testing as otherwise the server never closes. Now `supertest` can open and close the server. According to FSO, this is best practice, link below if you want to check it out:

https://fullstackopen.com/en/part4/structure_of_backend_application_introduction_to_testing#project-structure