### PR TITLE
reversed order of deletions

### DIFF
--- a/src/model/test-db-reset.ts
+++ b/src/model/test-db-reset.ts
@@ -1,11 +1,13 @@
-const reset = `DELETE FROM users;
-DELETE FROM admins;
-DELETE FROM languages;
-DELETE FROM words;
-DELETE FROM texts;
-DELETE FROM translations;
-DELETE FROM contexts;
+const reset = `
+DELETE FROM webdictionaries;
 DELETE FROM languagepairs;
-DELETE FROM webdictionaries;`.split('\n');
+DELETE FROM contexts;
+DELETE FROM translations;
+DELETE FROM texts;
+DELETE FROM words;
+DELETE FROM languages;
+DELETE FROM admins;
+DELETE FROM users;
+`.split('\n');
 
 export default reset;

--- a/src/model/test-db-reset.ts
+++ b/src/model/test-db-reset.ts
@@ -1,5 +1,4 @@
-const reset = `
-DELETE FROM webdictionaries;
+const reset = `DELETE FROM webdictionaries;
 DELETE FROM languagepairs;
 DELETE FROM contexts;
 DELETE FROM translations;
@@ -7,7 +6,6 @@ DELETE FROM texts;
 DELETE FROM words;
 DELETE FROM languages;
 DELETE FROM admins;
-DELETE FROM users;
-`.split('\n');
+DELETE FROM users;`.split('\n');
 
 export default reset;


### PR DESCRIPTION
Had to reverse the order of Eamon's reset file's deletions to avoid foreign key errors from remainders of Dana's translation test suite. 

Lesson: Always clean up the database after your tests have run!